### PR TITLE
chore: fix logo link

### DIFF
--- a/examples/Instance_segmentation_stomavision.ipynb
+++ b/examples/Instance_segmentation_stomavision.ipynb
@@ -5,7 +5,7 @@
    "id": "5a5e7165-fde0-499d-be1e-4ab71a8ecd3d",
    "metadata": {},
    "source": [
-    "<img src=\"https://raw.githubusercontent.com/instill-ai/cookbook/george/mar-100/images/Logo.png\" alt=\"Instill Logo\" width=\"300\"/>"
+    "<img src=\"https://raw.githubusercontent.com/instill-ai/cookbook/main/images/Logo.png\" alt=\"Instill Logo\" width=\"300\"/>"
    ]
   },
   {


### PR DESCRIPTION
Because

- logo link is broken

This commit

- fixes the link
